### PR TITLE
refactor: 💡 Use max array length as column size

### DIFF
--- a/asus_touchpad.py
+++ b/asus_touchpad.py
@@ -119,7 +119,7 @@ log.debug('Numpad min-max: x %d-%d, y %d-%d', minx_numpad,
           maxx_numpad, miny_numpad, maxy_numpad)
 
 # Detect col, row count from map of keys
-col_count = len(model_layout.keys[0])
+col_count = len(max(model_layout.keys, key=len))
 row_count = len(model_layout.keys)
 col_width = (maxx_numpad - minx_numpad) / col_count
 row_height = (maxy_numpad - miny_numpad) / row_count


### PR DESCRIPTION
Use max array length as column size instead of length of the first array
in matrix.
Fixes g533 layout (it doesn't work in the newest commit as arrays in the `keys` have different sizes) 