### PR TITLE
fix: :bug: Arch Linux & Fedora deps

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ fi
 if [[ $(sudo apt install 2>/dev/null) ]]; then
     echo 'apt is here' && sudo apt -y install libevdev2 python3-libevdev i2c-tools git python3-pip
 elif [[ $(sudo pacman -h 2>/dev/null) ]]; then
-    echo 'pacman is here' && sudo pacman --noconfirm -S libevdev python-libevdev i2c-tools git
+    echo 'pacman is here' && sudo pacman --noconfirm --needed -S libevdev python-libevdev i2c-tools git python-pip
 elif [[ $(sudo dnf install 2>/dev/null) ]]; then
     echo 'dnf is here' && sudo dnf -y install libevdev python-libevdev i2c-tools git
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Checking if the script is runned as root (via sudo or other)
 if [[ $(id -u) != 0 ]]
 then

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ if [[ $(sudo apt install 2>/dev/null) ]]; then
 elif [[ $(sudo pacman -h 2>/dev/null) ]]; then
     echo 'pacman is here' && sudo pacman --noconfirm --needed -S libevdev python-libevdev i2c-tools git python-pip
 elif [[ $(sudo dnf install 2>/dev/null) ]]; then
-    echo 'dnf is here' && sudo dnf -y install libevdev python-libevdev i2c-tools git
+    echo 'dnf is here' && sudo dnf -y install libevdev python-libevdev i2c-tools git python-pip
 fi
 
 pip3 install numpy


### PR DESCRIPTION
I've added `python-pip` package and added `--needed` flag for pacman to prevent reinstalling packages. I've also added `set -e` on top of the script, so the script will fail if it runs to any errors, but this would also mean the error messages are unnecessary. What's your (@ldrahnik) view on this?