### PR TITLE
Added reflecting status (enabled/disabled) of touchpad device

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ If you find a project useful, do not forget to give project a [![GitHub stars](h
 - Customizable default level of backlight
 - Smooth change of backlight levels (endless loop with customizable interval, default 1s)
 - Customizable slide gesture beginning on top left (default action is calculator with numpad activation and a requirement is end slide after atleast 0.3 of width and height)
+- Disabling Touchpad (e.g. Fn+special key) disables numpad aswell
 - Numlock state corresponds to the system numlock state (disabling sys numlock from e.g. external keyboard disables numpad aswell, reflect enabling sys numlock is optional)
 - Touchpad physical buttons (left, right and middle) are ignored when is numpad on
 - Repeat key pressing when a key is held (optional)
@@ -113,8 +114,9 @@ Example: If you want to set the activation time to 2 seconds and you have chosen
 
 | Option                      | Required    | Default | Description                                                       |
 | --------------------------- | ------------|---------|-------------------------------------------------------------------|
-| **System numlock**          |             |           | obtained via active `LED_NUML` of keyboard device
-| `sys_numlock_enables_numpad`|             | `False`   | enable with `True`, by default numpad reflects only disabling system numlock (then is disabled)
+| **System**          |             |           | 
+| `touchpad_disables_numpad`|             | `True`   | when is touchpad disabled (e.g. via Fn+special key) is disabled numpad aswell, valid value is `True` of `False`
+| `sys_numlock_enables_numpad`|             | `False`   | obtained via active `LED_NUML` of keyboard device<br><br>enable with `True`, by default numpad reflects only disabling system numlock (then is disabled)
 | **Device search**           |             |           | `/proc/bus/input/devices`
 | `try_times`                 |             | 5         | how many times to try find a touchpad device in each service start attempt  
 | `try_sleep`                 |             | 0.1 [s]   | time between tries

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Example: If you want to set the activation time to 2 seconds and you have chosen
 | Option                      | Required    | Default | Description                                                       |
 | --------------------------- | ------------|---------|-------------------------------------------------------------------|
 | **System**          |             |           | 
-| `touchpad_disables_numpad`|             | `True`   | when is touchpad disabled (e.g. via Fn+special key) is disabled numpad aswell, valid value is `True` of `False`
+| `touchpad_disables_numpad`|             | `True`   | when is touchpad disabled (e.g. via Fn+special key) is disabled numpad aswell, valid value is `True` or `False`
 | `sys_numlock_enables_numpad`|             | `False`   | obtained via active `LED_NUML` of keyboard device<br><br>enable with `True`, by default numpad reflects only disabling system numlock (then is disabled)
 | **Device search**           |             |           | `/proc/bus/input/devices`
 | `try_times`                 |             | 5         | how many times to try find a touchpad device in each service start attempt  

--- a/asus_touchpad.py
+++ b/asus_touchpad.py
@@ -489,7 +489,8 @@ def local_numlock_pressed():
     if numlock:
 
         is_touchpad_enabled = is_device_enabled(touchpad_name)
-        if is_touchpad_enabled:
+        if touchpad_disables_numpad and is_touchpad_enabled or\
+            not touchpad_disables_numpad:
 
             if not sys_numlock:
                 send_numlock_key(1)

--- a/asus_touchpad.py
+++ b/asus_touchpad.py
@@ -32,6 +32,7 @@ model_layout = importlib.import_module('numpad_layouts.' + model)
 
 percentage_key: libevdev.const = EV_KEY.KEY_5
 
+touchpad_disables_numpad = getattr(model_layout, "touchpad_disables_numpad", True)
 key_repetitions = getattr(model_layout, "key_repetitions", False)
 multitouch = getattr(model_layout, "multitouch", False)
 one_touch_key_rotation = getattr(model_layout, "one_touch_key_rotation", False)
@@ -79,6 +80,7 @@ if len(sys.argv) > 2:
 
 # Figure out devices from devices file
 touchpad: Optional[str] = None
+touchpad_name: Optional[str] = None
 keyboard: Optional[str] = None
 dev_k = None
 numlock: bool = False
@@ -97,6 +99,7 @@ while try_times > 0:
             if touchpad_detected == 0 and ("Name=\"ASUE" in line or "Name=\"ELAN" in line) and "Touchpad" in line:
                 touchpad_detected = 1
                 log.debug('Detect touchpad from %s', line.strip())
+                touchpad_name = line.split("\"")[1]
 
             if touchpad_detected == 1:
                 if "S: " in line:
@@ -484,13 +487,18 @@ def local_numlock_pressed():
 
     # Activating
     if numlock:
-        if not sys_numlock:
-            send_numlock_key(1)
-            send_numlock_key(0)
-            log.info("System numlock activated")
 
-        log.info("Numpad activated")
-        activate_numpad()
+        is_touchpad_enabled = is_device_enabled(touchpad_name)
+        if is_touchpad_enabled:
+
+            if not sys_numlock:
+                send_numlock_key(1)
+                send_numlock_key(0)
+                log.info("System numlock activated")
+
+            log.info("Numpad activated")
+            activate_numpad()
+
     # Inactivating
     else:
         if sys_numlock:
@@ -734,16 +742,56 @@ def listen_touchpad_events():
                 unpressed_numpad_key()
 
 
+# Gets the enable device property for the device Id  
+def is_device_enabled(device_name):
+    propData = subprocess.check_output(['xinput', '--list-props', device_name])
+    propData = propData.decode()
+
+    for line in propData.splitlines():
+        if 'Device Enabled' in line:
+            line = line.strip()
+            if line[-1] == '1':
+                return True
+            else:
+                return False
+
+    return False
+
+
+def check_touchpad_status():
+    global touchpad_name, numlock, touchpad_disables_numpad
+
+    is_touchpad_enabled = is_device_enabled(touchpad_name)
+
+    if not is_touchpad_enabled and touchpad_disables_numpad and numlock:
+        numlock = False
+        deactivate_numpad()
+        log.info("Numpad deactivated")
+
+
 def check_system_numlock_status():
     while True:
         check_system_numlock_vs_local()
         sleep(0.5)
 
+
+def check_touchpad_status_endless_cycle():
+    while True:
+        check_touchpad_status()
+        sleep(0.5)
+
+
+threads = []
 # if keyboard with numlock indicator was found
 # thread for listening change of system numlock
 if dev_k:
-    threads = []
     t = threading.Thread(target=check_system_numlock_status)
+    threads.append(t)
+    t.start()
+
+# if disabling touchpad disables numpad aswell
+if d_t and touchpad_name and touchpad_disables_numpad:
+    t = threading.Thread(target=check_touchpad_status_endless_cycle)
     threads.append(t)
     t.start()
 


### PR DESCRIPTION
Has to be enabled touchpad device otherwise is not possible by default start numpad.
-> disabling touchpad via
```
xinput disable 13 # id from list `xinput` in code is disabled implemented by name
```

or `Fn+special key` disables numpad aswell. But not a numlock! Can be changed via option.