### PR TITLE
refactor: 💡 Refactor dependecies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,33 +50,20 @@ and to uninstall, just run:
 sudo ./uninstall.sh
 ```
 
-### Required packages
+### Dependencies
 
 **Everything is included in install script `sudo ./install.sh`**
 
-- Debian / Ubuntu (22.04 is supported) / Linux Mint / Pop!\_OS / Zorin OS:
+- libevdev
+- i2c-tools
+- git
+- xinput
 
-```bash
-sudo apt install libevdev2 python3-libevdev i2c-tools git python3-pip xinput
-```
+#### Python dependencies
 
-- Arch Linux / Manjaro:
-
-```bash
-sudo pacman -S libevdev python-libevdev i2c-tools git python-pip xorg-xinput
-```
-
-- Fedora:
-
-```bash
-sudo dnf install libevdev python-libevdev i2c-tools git python-pip xinput
-```
-
-Python lib NumPy, evdev
-
-```bash
-pip3 install numpy evdev
-```
+- libevdev
+- numpy
+- evdev
 
 Then enable i2c
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ sudo modprobe i2c-dev
 sudo i2cdetect -l
 ```
 
+To see the exact commands for your package manager look [here](./install.sh)
+
 ## Troubleshooting
 
 To show debug logs run:

--- a/install.sh
+++ b/install.sh
@@ -7,19 +7,11 @@ if [[ $(id -u) != 0 ]]; then
 fi
 
 if [[ $(sudo apt install 2>/dev/null) ]]; then
-    echo 'apt is here' && sudo apt -y install libevdev2 python3-libevdev i2c-tools git python3-pip xinput
+    echo 'apt is here' && sudo apt -y install libevdev2 python3-libevdev i2c-tools git python3-pip xinput python3-numpy python3-evdev
 elif [[ $(sudo pacman -h 2>/dev/null) ]]; then
-    echo 'pacman is here' && sudo pacman --noconfirm --needed -S libevdev python-libevdev i2c-tools git python-pip xorg-xinput
+    echo 'pacman is here' && sudo pacman --noconfirm --needed -S libevdev python-libevdev i2c-tools git xorg-xinput python-numpy python-evdev
 elif [[ $(sudo dnf install 2>/dev/null) ]]; then
-    echo 'dnf is here' && sudo dnf -y install libevdev python-libevdev i2c-tools git python-pip xinput
-fi
-
-pip3 install numpy evdev
-
-# Checking if the pip3 is successfuly loaded
-if [[ $? != 0 ]]; then
-    echo "pip3 is not loaded correctly. Make sure you have installed python3-pip package"
-    exit 1
+    echo 'dnf is here' && sudo dnf -y install libevdev python-libevdev i2c-tools git xinput python-evdev python3-numpy
 fi
 
 modprobe i2c-dev


### PR DESCRIPTION
I switched all packages to the package manager's versions, as we already installed python libevdev (`python3-libevdev`)  dependency through them. Also, I listed the dependencies and removed the installation commands from README as they are already in the installation script and I added a notice for where to look for them. I consider the installation commands in README unnecessary, as *we* recommend using the install script.